### PR TITLE
Bug fixes

### DIFF
--- a/FDOM.Core/Common.fs
+++ b/FDOM.Core/Common.fs
@@ -102,6 +102,12 @@ module DOM =
                 | InlineContent.Span s -> s.Content
                 | InlineContent.Link l -> l.Content)
             |> String.concat ""
+            
+        member ic.Append(str: string) =
+            match ic with
+            | Text it -> { it with Content = $"{it.Content}{str}" } |> InlineContent.Text
+            | Span is -> { is with Content = $"{is.Content}{str}" } |> InlineContent.Span
+            | Link il -> { il with Content = $"{il.Content}{str}" } |> InlineContent.Link
 
     and Section =
         { Style: Style

--- a/FDOM.Core/Parsing.fs
+++ b/FDOM.Core/Parsing.fs
@@ -382,6 +382,8 @@ module InlineParser =
                         let (sub, next) =
                             readUntilCtrlChar input (i + 1)
                             
+                        // TODO get last item from state and append "_" + sub to it.
+                            
                         (state @ [ DOM.InlineContent.Text { Content = sub } ], next)
                     | _ ->
                         let (sub, next) = readUntilCtrlChar input i

--- a/FDOM.Core/Parsing.fs
+++ b/FDOM.Core/Parsing.fs
@@ -342,9 +342,21 @@ module InlineParser =
                         let ((sub, next), classes) =
                             match lookAhead input i 1, lookAhead input i 2 with
                             | Some (c1), Some (c2) when c1 = '*' && c2 = '*' ->
-                                readUntilString input "***" true i, [ "b"; "i" ]
-                            | Some (c1), _ when c1 = '*' -> readUntilString input "**" true i, [ "b" ]
-                            | _ -> readUntilChar input '*' true (i + 1), [ "i" ]
+                                let (sub, next) = readUntilString input "***" true i
+                                let adjustedSub =
+                                    if (next >= input.Length) then sub.Remove(sub.Length - 3, 3) else sub 
+                                
+                                (adjustedSub, next), [ "b"; "i" ]
+                            | Some (c1), _ when c1 = '*' ->
+                                let (sub, next) = readUntilString input "**" true i
+                                let adjustedSub =
+                                    if (next >= input.Length) then sub.Remove(sub.Length - 2, 2) else sub 
+                                (adjustedSub, next), [ "b" ]
+                            | _ ->
+                                let (sub, next) = readUntilChar input '*' true (i + 1)
+                                let adjustedSub =
+                                    if (next >= input.Length) then sub.Remove(sub.Length - 1, 1) else sub
+                                readUntilChar input '*' true (i + 1), [ "i" ]
 
                         let content =
                             DOM.InlineContent.Span

--- a/FDOM.Core/Parsing.fs
+++ b/FDOM.Core/Parsing.fs
@@ -391,11 +391,22 @@ module InlineParser =
                         let (sub, next) =
                             readUntilCtrlChar input (i + 1)
 
-                        // TODO get last item from state and append "_" + sub to it.
+                        // Get last item from state and append "_" + sub to it.
+                        // Fix for #8 and #9
+                        let newIc =
+                            state
+                            |> List.rev
+                            |> List.tryHead
+                            |> Option.map (fun ic -> ic.Append($"_{sub}"))
+                            |> Option.defaultWith (fun _ -> DOM.InlineContent.Text { Content = $"_{sub}" })
 
+                        // Not the prettiest solution but it does get the job done.
+                        // Could be more efficient but in general this *shouldn't* be too much of an issue.
+                        // It passes tests for now. This could be reworked properly.
                         (state
-                         @ [ DOM.InlineContent.Text { Content = sub } ],
-                         next)
+                         |> List.rev
+                         |> List.tail
+                         |> fun t -> newIc :: t |> List.rev, next)
                     | _ ->
                         let (sub, next) = readUntilCtrlChar input i
 

--- a/FDOM.Core/Parsing.fs
+++ b/FDOM.Core/Parsing.fs
@@ -376,6 +376,13 @@ module InlineParser =
                                   Style = DOM.Style.Default }
 
                         (state @ [ content ], next)
+                    | '_' ->
+                        // To fix issue #8 and #9
+                        // Read until next control character and append to prev?
+                        let (sub, next) =
+                            readUntilCtrlChar input (i + 1)
+                            
+                        (state @ [ DOM.InlineContent.Text { Content = sub } ], next)
                     | _ ->
                         let (sub, next) = readUntilCtrlChar input i
 

--- a/FDOM.UnitTests/Core/Parsing.fs
+++ b/FDOM.UnitTests/Core/Parsing.fs
@@ -289,6 +289,7 @@ type InlineParsing() =
 
         Assert.AreEqual(expected, actual)
 
+    /// <summary>Test for fix to issues #8 and #9</summary>
     [<TestMethod>]
     member _.``Parse inline text content with underscore``() =
 
@@ -302,7 +303,7 @@ type InlineParsing() =
 
         Assert.AreEqual(expected, actual)
 
-
+    /// <summary>Test for fix to issues #8 and #9</summary>
     [<TestMethod>]
     member _.``Parse inline span content with underscore``() =
 
@@ -317,6 +318,57 @@ type InlineParsing() =
             InlineParser.parseInlineContent input
 
         Assert.AreEqual(expected, actual)
+
+    
+    /// <summary>Test for fix to issues #8 and #4</summary>
+    [<TestMethod>]
+    member _.``Parse inline span content to line end with b and i``() =
+
+        let input = "***hello world***"
+
+        let expected =
+            [ DOM.InlineContent.Span
+                  { Content = "hello world"
+                    Style = DOM.Style.Ref [ "b"; "i" ] } ]
+
+        let actual =
+            InlineParser.parseInlineContent input
+
+        Assert.AreEqual(expected, actual)
+        
+    
+    /// <summary>Test for fix to issues #8 and #4</summary>
+    [<TestMethod>]
+    member _.``Parse inline span content to line end with b``() =
+
+        let input = "**hello world**"
+
+        let expected =
+            [ DOM.InlineContent.Span
+                  { Content = "hello world"
+                    Style = DOM.Style.Ref [ "b" ] } ]
+
+        let actual =
+            InlineParser.parseInlineContent input
+
+        Assert.AreEqual(expected, actual)
+        
+     /// <summary>Test for fix to issues #8 and #4</summary>
+    [<TestMethod>]
+    member _.``Parse inline span content to line end with i``() =
+
+        let input = "*hello world*"
+
+        let expected =
+            [ DOM.InlineContent.Span
+                  { Content = "hello world"
+                    Style = DOM.Style.Ref [ "i" ] } ]
+
+        let actual =
+            InlineParser.parseInlineContent input
+
+        Assert.AreEqual(expected, actual)
+
 
 [<TestClass>]
 type Processing() =

--- a/FDOM.UnitTests/Core/Parsing.fs
+++ b/FDOM.UnitTests/Core/Parsing.fs
@@ -284,8 +284,38 @@ type InlineParsing() =
                     Style = DOM.Style.Default }
               DOM.InlineContent.Text { Content = ", hopefully it works!" } ]
 
-        let actual = InlineParser.parseInlineContent input
-        
+        let actual =
+            InlineParser.parseInlineContent input
+
+        Assert.AreEqual(expected, actual)
+
+    [<TestMethod>]
+    member _.``Parse inline text content with underscore``() =
+
+        let input = "hello_world"
+
+        let expected =
+            [ DOM.InlineContent.Text { Content = "hello_world" } ]
+
+        let actual =
+            InlineParser.parseInlineContent input
+
+        Assert.AreEqual(expected, actual)
+
+
+    [<TestMethod>]
+    member _.``Parse inline span content with underscore``() =
+
+        let input = "***hello_world***"
+
+        let expected =
+            [ DOM.InlineContent.Span
+                  { Content = "hello_world"
+                    Style = DOM.Style.Ref [ "b"; "i" ] } ]
+
+        let actual =
+            InlineParser.parseInlineContent input
+
         Assert.AreEqual(expected, actual)
 
 [<TestClass>]


### PR DESCRIPTION
A basic fix for #8 and #9. Though it needs to be refined/tidied up.

Things to consider:

* If `_` should the text (and `_`) be appending to the item in the parser state?
* What if `_` is at the beginning of the sentence?
* Should `InlineContent` have a `Append(str)` method? (Probably yes) 