### PR TITLE
Add core Footnote and BlockQuote BlockType

### DIFF
--- a/FDOM.Core/Common.fs
+++ b/FDOM.Core/Common.fs
@@ -91,6 +91,11 @@ module DOM =
     and FootnoteBlock =
         { Name: string
           Paragraphs: ParagraphBlock }
+        
+    and BlockQuoteBlock =
+        {
+            Content: BlockContent list
+        }
 
     and BlockContent =
         | Header of HeaderBlock
@@ -100,6 +105,7 @@ module DOM =
         | Image of ImageBlock
         | Table of TableBlock
         | FootNote of FootnoteBlock
+        | BlockQuote of BlockQuoteBlock
 
         member bc.GetRawText() =
             match bc with
@@ -254,7 +260,6 @@ module DOM =
 
     let createSpan style text =
         InlineContent.Span { Style = style; Content = text }
-
 
     let createLink style text url =
         InlineContent.Link

--- a/FDOM.Core/Parsing.fs
+++ b/FDOM.Core/Parsing.fs
@@ -56,6 +56,8 @@ module BlockParser =
         | Image of Text: string
         | Table of Text: string
         | InlineMetadata of Text: string
+        | Footnote of Text: string
+        | BlockQuote of Text: string
         | Empty
 
     [<RequireQualifiedAccess>]
@@ -120,7 +122,7 @@ module BlockParser =
     let tryParseParagraph (formatter: Line list -> string) (input: Input) curr =
         match input.TryGetLine curr with
         | None -> Error()
-        | Some l when l.Type <> LineType.Text -> Error()
+        | Some l when l.Type <> LineType.Text && l.Type <> LineType.IndentedText -> Error()
         | _ ->
             // This looks for text or indented text because paragraph lines could start with a space.
             let lines, next = input.TryGetUntilNotTypesOrEnd(curr, [ LineType.Text; LineType.IndentedText ])
@@ -219,6 +221,11 @@ module BlockParser =
         match input.TryGetLine curr with
         | None -> Error()
         | Some l when l.Type <> LineType.Footnote -> Error()
+        | Some l ->
+            
+            
+            
+            Ok (BlockToken.Header)
     
     let tryParseBlockQuote (input: Input) curr =
         

--- a/FDOM.Core/Parsing.fs
+++ b/FDOM.Core/Parsing.fs
@@ -271,6 +271,8 @@ module BlockParser =
 
         handler ([], 0)
 
+open BlockParser
+
 /// The inline parse takes block tokens and creates a DOM.
 module InlineParser =
 
@@ -643,6 +645,8 @@ module Processing =
                         (p Style.none [ DOM.InlineContent.Text { Content = "" } ], remainingBlocks.Tail)
                     | BlockParser.BlockToken.Empty _ ->
                         (p Style.none [ DOM.InlineContent.Text { Content = "" } ], remainingBlocks.Tail)
+                    | BlockToken.Footnote text -> failwith "todo"
+                    | BlockToken.BlockQuote text -> failwith "todo"
 
                 handler (append processedBlocks newBlock, newRemainingBlocks)
 

--- a/FDOM.Core/Parsing.fs
+++ b/FDOM.Core/Parsing.fs
@@ -486,7 +486,6 @@ module Processing =
             (Style.references [ lang |> Option.map (fun l -> $"language-{l}") |> Option.defaultValue "" ])
             [ DOM.InlineContent.Text { Content = value } ]
 
-
     let createImageBlock (value: string) =
         // Split the image into parts.
 
@@ -513,7 +512,6 @@ module Processing =
                 (None, None)
 
         img Style.none url title altText height width
-
 
     let createListItem (value: string) =
         li Style.none (InlineParser.parseInlineContent value)


### PR DESCRIPTION
Add support for footnotes and block quotes.

- [x] Add `LineType.Footnote` to `Core/Parsing.fs`
- [x] Add `LineType.IndentedText` to `Core/Parsing.fs`
- [x] Add `LineType.BlockQuote` to `Core/Parsing.fs`
- [x] Add `BlockToken.Footnote` to `Core/Parsing.fs` 
- [x] Add `BlockToken.BlockQuote` to `Core/Parsing.fs`
- [ ] Add `tryParseFootnote` to `Core/Parsing.fs`
- [ ] Add `tryParseBlockQuote` to `Core/Parsing.fs`
- [x] Add `InlineContent.FootnoteReference` to `Core/Common.fs`
- [x] Add tests for `InlineContent.FootnoteReference`
- [ ] Add tests for `LineType.Footnote`
- [x] Add tests for `LineType.IndentedText`
- [ ] Add tests for `LineType.BlockQuote`

This is an overview of the steps required. However it can grow, for example block quotes should support nested block quotes etc.

This is separate to renderer support. 